### PR TITLE
Remove Domain Requirement for URL Validation

### DIFF
--- a/src/options/helpers.js
+++ b/src/options/helpers.js
@@ -34,8 +34,9 @@ export const guid = () => {
 };
 
 export const isValidURL = string => {
+  // Allows anything to be between http(s):// and the first slash
   var res = string.match(
-    /(http(s)?:\/\/.)(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g
+      /^(http(s)?)?:\/\/([^\/\s]+)(\/.*)?$/g
   );
   if (res == null) return false;
   else return true;


### PR DESCRIPTION
Changed the regex used inside the `isValidURL()` helper function to allow users to add any type of user as long as the url is in a generally valid format. Specifically I needed to be able to change add a url for a with an IP and port but the current validation prevented it.

I change the regex pattern to the following:
`/^(http(s)?)?:\/\/([^\/\s]+)(\/.*)?$/g`

This will allows anything to be between the `http(s)://` and the first `/`.
Allowing for ipv4, ipv6, domain names as well as all those with ports. Feel free to remove the comment I added to explain the regex change. You could go a step further and allow the `file:///` protocol as well, but I wanted to keep the sanity in place.