### PR TITLE
FIX: Edge Case on Long URL Causes Poor Overflow of Table Contents

### DIFF
--- a/stylesheets/app.css
+++ b/stylesheets/app.css
@@ -35,3 +35,8 @@
 .mt-5 {
   margin-top: 50px;
 }
+
+td {
+  max-width: 500px;
+  overflow: auto;
+}


### PR DESCRIPTION
This is an edge case, but a very specific, yet valid URLs, like shown at the bottom of this comment, may not properly overflowed / wrapped  in Chrome.

This causes the "Delete" icon for all rows to be pushed off the screen and it becomes impossible to scroll right, or even zoom out, to see that part of the screen.

**Example of the problem**
![image](https://user-images.githubusercontent.com/1777776/129489226-47ea5966-617b-4582-b144-45ee50c6c1b5.png)

This doesn't happen with all long URLs. For instance, if a really long URL has dash characters, then Chrome will wrap it. However, for valid URLs that have a long query string with HTML encoded elements, it will cause the issue to appear.

There may be a more elegant CSS solution, but adding a `max-width: 500px` and `overflow:auto` did the trick, so that's what I've submitted for this PR.

**Example of a Fix with this PR Applied**
![image](https://user-images.githubusercontent.com/1777776/129489305-0249f3ad-8df5-4d57-9760-a7883946797b.png)

**Below is a Valid URL that Causes the Issue**
I changed the domain name, but this was a real URL I needed to alias.

`https://example.com/app#/reports/sales?filter_by=PreviousMonth&from_date=2021-06-01&rule=%7B%22columns%22%3A%5B%7B%22index%22%3A1%2C%22field%22%3A%22item_name%22%2C%22value%22%3A%22Sales%22%2C%22comparator%22%3A%22not_contains%22%2C%22group%22%3A%22report%22%7D%2C%7B%22index%22%3A2%2C%22field%22%3A%22item_name%22%2C%22value%22%3A%22Commitment%22%2C%22comparator%22%3A%22not_contains%22%2C%22group%22%3A%22report%22%7D%5D%2C%22criteria_string%22%3A%22(%201%20AND%202%20)%22%7D&select_columns=%5B%7B%22field%22%3A%22item_name%22%2C%22group%22%3A%22report%22%7D%2C%7B%22field%22%3A%22sku%22%2C%22group%22%3A%22item%22%7D%2C%7B%22field%22%3A%22quantity_sold%22%2C%22group%22%3A%22report%22%7D%2C%7B%22field%22%3A%22amount%22%2C%22group%22%3A%22report%22%7D%2C%7B%22field%22%3A%22average_price%22%2C%22group%22%3A%22report%22%7D%5D&sort_column=amount&sort_order=D&to_date=2021-06-30`

Thanks for this plugin. I was using another one for years and Google shut them down, so trying this out.